### PR TITLE
Add database filter

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -76,8 +76,16 @@ func init() {
 
 			// database flag
 			if cCtx.Bool("database") {
-				fmt.Printf("Args: %s", strings.Join(args, ", "))
-				fmt.Println("Checking if words are reserved in database languages...")
+				words := r.CheckDatabase(args...)
+				if len(words) > 0 {
+					fmt.Println(wordsAreReserved)
+					fmt.Println()
+					fmt.Printf("%s", words.String())
+					fmt.Println()
+					fmt.Println()
+				} else {
+					fmt.Println(wordsAreNotReserved)
+				}
 				return nil
 			}
 

--- a/pkg/reserved/reserved.go
+++ b/pkg/reserved/reserved.go
@@ -73,6 +73,26 @@ func (r *Reserved) CheckProgramming(words ...string) Checked {
 	return result
 }
 
+// Check if word(s) are reserved in database languages
+// returns a slice of languages the word is reserved in
+func (r *Reserved) CheckDatabase(words ...string) Checked {
+	d := data.Get()
+	result := make(map[string][]string)
+
+	for _, l := range d.Languages {
+		if l.Kind == "database" {
+			for _, w := range words {
+				for _, lw := range l.Words {
+					if lw == w {
+						result[l.Name] = append(result[l.Name], w)
+					}
+				}
+			}
+		}
+	}
+	return result
+}
+
 // String output when printing checked
 func (c Checked) String() string {
 	var (


### PR DESCRIPTION
Partially resolves #6. 

Adds a `-d` flag to check word(s) only against database languages. Extended functionality mentioned in #6 to be implemented in separate PRs, such as filtering by specific database languages `-d mysql postgres`.